### PR TITLE
Add Docker setup for MCP server

### DIFF
--- a/RAG/backend/DockerFile
+++ b/RAG/backend/DockerFile
@@ -1,6 +1,18 @@
 FROM python:3.10-slim
+
+# Utilise un dossier de travail classique
 WORKDIR /app
-COPY requirements.txt ./
+
+# Installation des dépendances du serveur MCP
+COPY mcp_server/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . ./
-CMD ["uvicorn", "api.app:app", "--host", "0.0.0.0", "--port", "8000"]
+
+# Copie du code source
+COPY . .
+
+# Le serveur MCP écoute par défaut sur 127.0.0.1:8000.
+# On force l'écoute sur toutes les interfaces pour l'accès extérieur.
+ENV FASTMCP_HOST=0.0.0.0
+
+# Lance le serveur MCP
+CMD ["python", "mcp_server/main.py"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# GPAC MCP Server
+
+Ce dépôt contient un serveur MCP permettant d'interroger la documentation GPAC.
+
+## Construction de l'image Docker
+
+```bash
+docker build -t gpac-mcp-server -f RAG/backend/DockerFile RAG/backend
+```
+
+## Lancement du conteneur
+
+```bash
+docker run -p 8000:8000 gpac-mcp-server
+```
+
+Le serveur sera alors disponible sur `http://localhost:8000` (ou l'adresse de
+votre machine). Configurez Claude Desktop pour utiliser cette URL afin de
+contacter l'instance MCP sans devoir la lancer manuellement à chaque fois.
+


### PR DESCRIPTION
## Summary
- update Dockerfile to run MCP server and install its requirements
- document how to build and run the container in a new README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845946b335c8325995e300fd055c243